### PR TITLE
Bump to 2.0.3-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2022-02-28
+
 - Updated end-to-end tests, by [@compulim](https://github.com/compulim), in PR [#25](https://github.com/compulim/markdown-it-attrs-es5/pull/25)
    - Using Docker to isolate tests
    - Test against different combinations of Node.js, NPM, and resolvers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-it-attrs-es5",
-  "version": "2.0.2",
+  "version": "2.0.3-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-it-attrs-es5",
-      "version": "2.0.2",
+      "version": "2.0.3-0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-it-attrs-es5",
-  "version": "2.0.2-0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-it-attrs-es5",
-      "version": "2.0.2-0",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-attrs-es5",
-  "version": "2.0.2-0",
+  "version": "2.0.2",
   "description": "",
   "engines": {
     "node": ">= 12.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-attrs-es5",
-  "version": "2.0.2",
+  "version": "2.0.3-0",
   "description": "",
   "engines": {
     "node": ">= 12.2.0"


### PR DESCRIPTION
## Summary

Bump version to `2.0.3-0` after releasing `2.0.2`.

## Changelog

(No changelog for bump version.)

## Design considerations

Steps to release and bump versions:

```sh
git fetch --all
git checkout origin/main
git clean -fdx
git checkout -b bump-2.0.3-0
vi CHANGELOG.md # mark changes to release in 2.0.2
git commit -a -m "2.0.2"
npm version patch
git push -u origin v2.0.2 # release 2.0.2 to npm
npm version prepatch --no-git-tag-version
git commit -a -m "2.0.3-0"
git push -u origin bump-2.0.3-0
```

## Specific changes

- Release `2.0.2`
- Add date to `CHANGELOG.md`
- Run `npm version prepatch`

## Reminders

<!-- Checks all boxes even if it is irrelevant to this pull request. -->

- [x] I have updated `CHANGELOG.md`
- [x] I have added tests for new code
- [x] I have updated documentations
